### PR TITLE
enable rule to be marked as restat or generator

### DIFF
--- a/source/ninja-build-gen.coffee
+++ b/source/ninja-build-gen.coffee
@@ -101,10 +101,20 @@ class NinjaRuleBuilder
         @dependencyFile = file
         this
 
+    restat: (doRestat) ->
+        @doRestat = doRestat
+        this
+
+    generator: (isGenerator) ->
+        @isGenerator = isGenerator
+        this
+
     # Write the rule into a `stream`.
     write: (stream) ->
         stream.write "rule #{@name}\n  command = #{@command}\n"
         stream.write "  description = #{@desc}\n" if @desc?
+        stream.write "  restat = 1\n" if @doRestat
+        stream.write "  generator = 1\n" if @isGenerator
         if @dependencyFile?
             stream.write "  depfile = #{@dependencyFile}\n"
             stream.write "  deps = gcc\n"

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -43,6 +43,24 @@ describe 'ninja', ->
                   deps = gcc\n
                 """
 
+        it 'should enable restat', ->
+            ninja.rule('coffee')
+                .restat(true)
+            compareToString ninja,
+                """
+                rule coffee
+                  command = \n  restat = 1\n
+                """
+
+        it 'should label as generator', ->
+            ninja.rule('coffee')
+                .generator(true)
+            compareToString ninja,
+                """
+                rule coffee
+                  command = \n  generator = 1\n
+                """
+
     describe '#edge', ->
         it 'should create a simple phony edge', ->
             ninja.edge('simple_phony')


### PR DESCRIPTION
Ninja rules have two special situations, restat and generator. This commit adds support for both of them.
