### PR TITLE
Set up Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+node_js:
+- '0.10'
+- '4'
+- '6'
+- node
+script:
+  - npm run prepublish
+  # make sure there are no changes from running the build scripts
+  - git diff HEAD --quiet

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # ninja-build-gen
+[![Build Status](https://travis-ci.org/jeanlauliac/ninja-build-gen.svg?branch=master)](https://travis-ci.org/jeanlauliac/ninja-build-gen)
 
 Create [Ninja](http://martine.github.io/ninja/) build-system manifests from
 JavaScript. This can be used for build in any kind of project, though (Ruby,

--- a/package.json
+++ b/package.json
@@ -17,8 +17,12 @@
     "url": "https://raw.github.com/jeanlauliac/ninja-build-gen/master/LICENSE"
   },
   "author": "Jean Lauliac <jean@lauliac.com>",
-  "contributors": ["Tylor Reynolds"],
-  "files": ["lib"],
+  "contributors": [
+    "Tylor Reynolds"
+  ],
+  "files": [
+    "lib"
+  ],
   "main": "lib/ninja-build-gen.js",
   "repository": {
     "type": "git",
@@ -32,15 +36,16 @@
     "source-map-support": "^0.4.0"
   },
   "devDependencies": {
+    "coffee-script": "~1.6.3",
     "coffeelint": "~0.5.6",
     "grunt": "~0.4.1",
-    "grunt-contrib-coffee": "~0.7.0",
-    "matchdep": "~0.1.1",
+    "grunt-cli": "^1.2.0",
     "grunt-coffeelint": "0.0.7",
-    "mocha": "~1.12.0",
+    "grunt-contrib-coffee": "~0.7.0",
     "grunt-mocha": "~0.3.4",
-    "coffee-script": "~1.6.3",
-    "grunt-mocha-test": "~0.5.0"
+    "grunt-mocha-test": "~0.5.0",
+    "matchdep": "~0.1.1",
+    "mocha": "~1.12.0"
   },
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
Set up Travis CI which will help use check pull-requests if we enable it. ~Had to rename the `prebuild` script because it attempts to run before you run install.~